### PR TITLE
[#6] feat : Column Row 컴포넌트 추가

### DIFF
--- a/src/styles/Layouts/Column.tsx
+++ b/src/styles/Layouts/Column.tsx
@@ -1,0 +1,55 @@
+import styled, { css } from "styled-components";
+
+type ColumnProps = {
+  verticalAlign?: "center" | "top" | "bottom" | "distribute";
+  horizonAlign?: "center" | "left" | "right" | "distribute";
+  gap?: number;
+};
+
+const ColumnCSS = (props?: ColumnProps) => css`
+  display: flex;
+  flex-direction: column;
+  align-items: ${(() => {
+    if (props?.verticalAlign) {
+      switch (props.verticalAlign) {
+        case "center":
+          return "center";
+        case "top":
+          return "flex-start";
+        case "bottom":
+          return "flex-end";
+      }
+    } else {
+      return "flex-start";
+    }
+  })()};
+  justify-content: ${(() => {
+    if (props?.horizonAlign) {
+      switch (props.horizonAlign) {
+        case "center":
+          return "center";
+        case "left":
+          return "flex-start";
+        case "right":
+          return "flex-end";
+        case "distribute":
+          return "space-between";
+      }
+    } else {
+      return "flex-start";
+    }
+  })()};
+  gap: ${(() => {
+    if (props?.gap) {
+      return `${props.gap}px`;
+    } else {
+      return 0;
+    }
+  })()};
+`;
+
+const Column = styled.div<ColumnProps>`
+  ${(props) => ColumnCSS(props)}
+`;
+
+export default Column;

--- a/src/styles/Layouts/Row.tsx
+++ b/src/styles/Layouts/Row.tsx
@@ -1,0 +1,54 @@
+import styled, { css } from "styled-components";
+
+type RowProps = {
+  verticalAlign?: "center" | "top" | "bottom" | "distribute";
+  horizonAlign?: "center" | "left" | "right" | "distribute";
+  gap?: number;
+};
+
+const RowCSS = (props?: RowProps) => css`
+  display: flex;
+  align-items: ${(() => {
+    if (props?.verticalAlign) {
+      switch (props.verticalAlign) {
+        case "center":
+          return "center";
+        case "top":
+          return "flex-start";
+        case "bottom":
+          return "flex-end";
+      }
+    } else {
+      return "flex-start";
+    }
+  })()};
+  justify-content: ${(() => {
+    if (props?.horizonAlign) {
+      switch (props.horizonAlign) {
+        case "center":
+          return "center";
+        case "left":
+          return "flex-start";
+        case "right":
+          return "flex-end";
+        case "distribute":
+          return "space-between";
+      }
+    } else {
+      return "flex-start";
+    }
+  })()};
+  gap: ${(() => {
+    if (props?.gap) {
+      return `${props.gap}px`;
+    } else {
+      return 0;
+    }
+  })()};
+`;
+
+const Row = styled.div<RowProps>`
+  ${(props) => RowCSS(props)}
+`;
+
+export default Row;


### PR DESCRIPTION
``display: flex ; justify-content: center ; align-items : center;``
해당 코드를 중복되게 많이 사용하는 것같아 그에 맞는 컴포넌트를 생성하였습니다.

사용방법
Row.tsx (요소들을 가로로 정렬하고싶을 때 사용)
horizonAlign / verticalAlign / gap 세가지 요소 전부 선택사항
``<Row>{이 안에 어떠한 컴포넌트를 넣어도 상관 없음}</Row>``
=> gap이 4인 가로정렬을 하는것

Column.tsx (요소들을 세로로 정렬하고싶을 때 사용)

horizonAlign / verticalAlign / gap 세가지 요소 전부 선택사항

``<Column> {이 안에 어떠한 컴포넌트를 넣어도 상관 없음} </Column>``