### PR TITLE
우측 사이드 패널 기능 구현 (feat/#22 -> develop) 

### DIFF
--- a/src/component/Layout.tsx
+++ b/src/component/Layout.tsx
@@ -1,6 +1,6 @@
-import {useState} from 'react';
+import {useState, useEffect} from 'react';
 
-import {Outlet, useLocation} from "react-router-dom";
+import {Outlet, useLocation, useNavigate} from "react-router-dom";
 import { NavigationBar } from "./NavigationBar";
 import styled from "styled-components";
 import {HeaderLayout} from "./HeaderLayout";
@@ -8,11 +8,19 @@ import {useAuthStore} from "../store/feature/authStore";
 
 export const Layout = () => {
     const location = useLocation();
+    const navigate = useNavigate();
     const { isLoggedIn } = useAuthStore(); // ✅ Zustand 활용
     const [loginState, setLoginState] = useState(isLoggedIn); // ✅ 로그인 상태 관리
     const handleLogin = () => setLoginState(true); // ✅ 로그인 처리 함수
 
     // const handleLogin = () => setIsLoggedIn(true); // 로그인 상태 변경
+
+    // ✅ "/" 경로로 접근하면 "/calendar"로 리다이렉트
+    useEffect(() => {
+        if (location.pathname === "/") {
+            navigate("/calendar", { replace: true });
+        }
+    }, [location.pathname, navigate]);
 
     // 객체 기반 페이지 매핑
     const pageMapping : {[key: string]: string} = {

--- a/src/pages/calendar/Calendar.tsx
+++ b/src/pages/calendar/Calendar.tsx
@@ -50,9 +50,9 @@ export const Calendar = ({year, month}: CalendarProps) => {
             {days.map((day, index) => (
                 <DayBox
                     key={index}
-                    isCurrentMonth={day.isCurrentMonth}
+                    $isCurrentMonth={day.isCurrentMonth}
                 >
-                    <DayNumber isToday={day.isToday}>{day.day}</DayNumber>
+                    <DayNumber $isToday={day.isToday}>{day.day}</DayNumber>
                     <Tasks>
                         {day.tasks.map((task, idx) => (
                             <Task key={idx}>{task}</Task>
@@ -73,7 +73,7 @@ const CalendarGrid = styled.div`
     border-radius: 16px;
 `;
 
-const DayBox = styled.div<DayBoxProps>`
+const DayBox = styled.div<{ $isCurrentMonth: boolean }>`
     display: flex;
     flex-direction: column;
     align-items: flex-start;
@@ -84,7 +84,7 @@ const DayBox = styled.div<DayBoxProps>`
     max-width: 140px;
     gap: 12px;
     border-radius: 16px;
-    opacity: ${({isCurrentMonth}) => (isCurrentMonth ? 1 : 0.4)};
+    opacity: ${({$isCurrentMonth}) => ($isCurrentMonth ? 1 : 0.4)};
     cursor: pointer;
 
     //&:hover {
@@ -92,17 +92,17 @@ const DayBox = styled.div<DayBoxProps>`
     //}
 `;
 
-const DayNumber = styled.div<{ isToday: boolean }>`
+const DayNumber = styled.div<{ $isToday: boolean }>`
     display: flex;
     justify-content: center;
     align-items: center;
     width: 40px;
     height: 40px;
     border-radius: 100px;
-    background: ${({ isToday, theme }) =>
-            isToday ? theme.colors.primary : "transparent"};
-    color: ${({ isToday, theme }) =>
-            isToday ? theme.colors.white : theme.colors.black};
+    background: ${({ $isToday, theme }) =>
+            $isToday ? theme.colors.primary : "transparent"};
+    color: ${({ $isToday, theme }) =>
+            $isToday ? theme.colors.white : theme.colors.black};
     font-size: 16px;
     font-weight: bold;
 `;

--- a/src/pages/calendar/Calendar.tsx
+++ b/src/pages/calendar/Calendar.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, {useEffect} from "react";
 import styled from "styled-components";
 import { useTasksStore } from "../../store/feature/tasksStore";
 import {useAuthStore} from "../../store/feature/authStore";
+import {usePlanStore} from "../../store/feature/planStore";
 
 interface DayBoxProps {
     isCurrentMonth: boolean;
@@ -17,26 +18,44 @@ const formatDateKey = (dateString: string): string => {
     return new Date(dateString).toISOString().split("T")[0]; // "2025-02-10"
 };
 
-const organizeTasksByDate = (tasks: { todoAt: string; title: string; color : string }[]) => {
-    return tasks.reduce((acc, task) => {
-        const dateKey = formatDateKey(task.todoAt);
-        if (!acc[dateKey]) acc[dateKey] = [];
+const organizeTasksByDate = (
+    tasks: { todoAt: string; title: string; color : string }[],
+    plans: {startDate: string; title: string; color: string }[],
+) => {
+    const mergedItems: Record<string, { title: string; color: string }[]> = {};
 
-        acc[dateKey].push({ title: task.title, color: task.color }); // 객체 형식으로 저장
-        return acc;
-    }, {} as Record<string, { title: string; color: string }[]>);
+    // 할 일 추가
+    tasks.forEach((task) => {
+        const dateKey = formatDateKey(task.todoAt);
+        if (!mergedItems[dateKey]) mergedItems[dateKey] = [];
+        mergedItems[dateKey].push({ title: task.title, color: task.color });
+    });
+
+    // 일정 추가
+    plans.forEach((plan: { startDate: string; title: string; color: string }) => {
+        const dateKey = formatDateKey(plan.startDate);
+        if (!mergedItems[dateKey]) mergedItems[dateKey] = [];
+        mergedItems[dateKey].push({ title: plan.title, color: plan.color });
+    });
+
+    return mergedItems;
 };
 
 export const Calendar = ({year, month}: CalendarProps) => {
     const { tasks } = useTasksStore();  // 할 일 데이터 가져오기
+    const { plans, fetchPlans } = usePlanStore();  // plans 가져오기 + fetchPlans 추가
     const { isLoggedIn } = useAuthStore(); // 로그인 상태 가져오기
 
-    // 날짜별 할 일 정리
-    const tasksByDate = organizeTasksByDate(tasks.map(task => ({
-        todoAt: task.todoAt,
-        title: task.title,
-        color: task.color,
-    })));
+    // 컴포넌트가 처음 렌더링될 때 일정 데이터 가져오기
+    useEffect(() => {
+        fetchPlans(year, month);
+    }, [year, month, fetchPlans]);
+
+    // 할 일 + 일정 함께 정리
+    const tasksAndPlansByDate = organizeTasksByDate(
+        tasks.map(task => ({ todoAt: task.todoAt, title: task.title, color: task.color })),
+        plans.map(plan => ({ startDate: plan.startDate, title: plan.title, color: plan.color }))
+    );
 
     const generateDays = (
         year: number,
@@ -74,7 +93,7 @@ export const Calendar = ({year, month}: CalendarProps) => {
         });
     };
 
-    const days = generateDays(year, month, tasksByDate);
+    const days = generateDays(year, month, tasksAndPlansByDate);
 
     return (
         <CalendarGrid>
@@ -154,15 +173,18 @@ const DayNumber = styled.div<{ $isToday: boolean }>`
 const Tasks = styled.div`
     display: flex;
     flex-direction: column;
+    width: 100%;
     gap: 4px;
     overflow: hidden;
+    min-height: 80px; /* 최소 높이 설정하여 개수가 적어도 동일한 높이 유지 */
 `;
 
 const Task = styled.div<{ color: string }>`
     display: flex;
     align-items: center;
-    min-width: 54px;
-    max-width: 124px;
+    min-width: 100px;  /* 최소 너비 통일 */
+    max-width: 120px; /* 최대 너비 설정 */
+    height: 15px; /* 일정한 높이 */
     padding: 2px 12px;
     gap: 10px;
     align-self: stretch;

--- a/src/pages/calendar/Calendar.tsx
+++ b/src/pages/calendar/Calendar.tsx
@@ -23,20 +23,20 @@ const organizeTasksByDate = (
     tasks: { todoAt: string; title: string; color : string }[],
     plans: {startDate: string; title: string; color: string }[],
 ) => {
-    const mergedItems: Record<string, { title: string; color: string }[]> = {};
+    const mergedItems: Record<string, { title: string; color: string; type: "tasks" | "plans" }[]> = {};
 
     // 할 일 추가
     tasks.forEach((task) => {
         const dateKey = formatDateKey(task.todoAt);
         if (!mergedItems[dateKey]) mergedItems[dateKey] = [];
-        mergedItems[dateKey].push({ title: task.title, color: task.color });
+        mergedItems[dateKey].push({ title: task.title, color: task.color, type: "tasks" });
     });
 
     // 일정 추가
     plans.forEach((plan: { startDate: string; title: string; color: string }) => {
         const dateKey = formatDateKey(plan.startDate);
         if (!mergedItems[dateKey]) mergedItems[dateKey] = [];
-        mergedItems[dateKey].push({ title: plan.title, color: plan.color });
+        mergedItems[dateKey].push({ title: plan.title, color: plan.color, type: "plans" });
     });
 
     return mergedItems;
@@ -54,14 +54,14 @@ export const Calendar = ({year, month, selectedTab}: CalendarProps) => {
 
     // 할 일 + 일정 함께 정리
     const tasksAndPlansByDate = organizeTasksByDate(
-        tasks.map(task => ({ todoAt: task.todoAt, title: task.title, color: task.color })),
-        plans.map(plan => ({ startDate: plan.startDate, title: plan.title, color: plan.color }))
+        tasks.map(task => ({ todoAt: task.todoAt, title: task.title, color: task.color, type: "tasks" })),
+        plans.map(plan => ({ startDate: plan.startDate, title: plan.title, color: plan.color, type: "plans" })),
     );
 
     const generateDays = (
         year: number,
         month: number,
-        tasksByDate: Record<string, { title: string; color: string }[]>
+        tasksByDate: Record<string, { title: string; color: string; type: "tasks" | "plans" }[]>
     ) => {
         const today = new Date(); // 오늘 날짜
         const isToday = (d: number, m: number, y: number) =>
@@ -100,15 +100,22 @@ export const Calendar = ({year, month, selectedTab}: CalendarProps) => {
         <CalendarGrid>
             {days.map((day, index) => {
                 //최대 3개의 일정만 표시
+                // const filteredTasks =
+                //     selectedTab === "tasks"
+                //         ? day.tasks.filter(task => !task.color.includes("#D9E2FF")) //일정과 할 일을 구분하는 조건 추가
+                //         : selectedTab === "plans"
+                //             ? day.tasks.filter(task => task.color.includes("#D9E2FF"))
+                //             : day.tasks; // "all"이면 전체 출력
+
                 const filteredTasks =
                     selectedTab === "tasks"
-                        ? day.tasks.filter(task => !task.color.includes("#D9E2FF")) //일정과 할 일을 구분하는 조건 추가
+                        ? day.tasks.filter(task => task.type === "tasks") // "tasks" 타입만 필터링
                         : selectedTab === "plans"
-                            ? day.tasks.filter(task => task.color.includes("#D9E2FF"))
+                            ? day.tasks.filter(task => task.type === "plans") // "plans" 타입만 필터링
                             : day.tasks; // "all"이면 전체 출력
 
-                const tasksToDisplay = isLoggedIn ? filteredTasks.slice(0, 3) : [];
-                const moreCount = isLoggedIn ? filteredTasks.length - 3 : 0;
+                const tasksToDisplay = isLoggedIn ? filteredTasks.slice(0, 2) : [];
+                const moreCount = isLoggedIn ? filteredTasks.length - 2 : 0;
 
                 return (
                     <DayBox key={index} $isCurrentMonth={day.isCurrentMonth}>
@@ -117,9 +124,16 @@ export const Calendar = ({year, month, selectedTab}: CalendarProps) => {
                             {/*로그인 상태일 때만 할 일(Task) 렌더링 */}
                             {isLoggedIn &&
                                 tasksToDisplay.map((task, idx) => (
-                                    <Task key={idx} color={task.color}>
-                                        {task.title}
-                                    </Task>
+                                    task.type === "plans" ? ( // 일정일 경우
+                                        <ScheduleTask>
+                                            <ScheduleTaskIndicator color={task.color} />
+                                            <ScheduleTaskText>{task.title}</ScheduleTaskText>
+                                        </ScheduleTask>
+                                    ) : ( // 할 일일 경우
+                                        <TodoTask key={idx} color={task.color}>
+                                            {task.title}
+                                        </TodoTask>
+                                    )
                                 ))
                             }
                             {/* 초과하는 일정이 있을 경우 "+N개" 표시 */}
@@ -189,12 +203,12 @@ const Tasks = styled.div`
     min-height: 80px; /* 최소 높이 설정하여 개수가 적어도 동일한 높이 유지 */
 `;
 
-const Task = styled.div<{ color: string }>`
+const TodoTask = styled.div<{ color: string }>`
     display: flex;
     align-items: center;
     min-width: 100px;  /* 최소 너비 통일 */
     max-width: 120px; /* 최대 너비 설정 */
-    height: 15px; /* 일정한 높이 */
+    height: 18px; /* 일정한 높이 */
     padding: 2px 12px;
     gap: 10px;
     align-self: stretch;
@@ -207,6 +221,56 @@ const Task = styled.div<{ color: string }>`
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+`;
+
+const ScheduleTask = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    min-width: 54px;  /* 최소 너비 */
+    max-width: 124px; /* 최대 너비 */
+    height: 18px;
+    border: 0.4px solid #CACCD7; /* 테두리 적용 */
+    background: #FFFFFF; /* 전체 배경은 흰색 */
+    font-size: 12px;
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    border-radius: 10.5px 10.5px 10.5px 10.5px; /* 오른쪽만 둥글게 */
+    align-self: stretch;  /* 부모 컨테이너 크기에 맞게 조절 */
+    position: relative;
+    box-sizing: border-box; /* border 포함 크기 조정 */
+    margin : 0;
+`;
+
+// 왼쪽 파란색 바
+const ScheduleTaskIndicator = styled.div<{color: string}>`
+    width: 12px;
+    height: 21px;
+    background: ${({color}) => color};
+    border-radius: 10.5px 0px 0px 10.5px;
+    // border: 0.4px solid #CACCD7;
+    flex-shrink: 0; /* 크기 축소 방지 */
+    box-sizing: border-box;
+    margin: 0;
+`;
+
+/* 일정 텍스트 컨테이너 */
+const ScheduleTaskText = styled.div`
+    display: flex;
+    align-items: center;
+    min-width: 42px;
+    max-width: 112px;
+    padding: 2px 12px 2px 8px;
+    // border: 0.4px solid #CACCD7;
+    background: #FFF;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    font-size: 12px;
+    font-weight: 500;
+    margin : 0;
 `;
 
 const MoreTasks = styled.div`

--- a/src/pages/calendar/Calendar.tsx
+++ b/src/pages/calendar/Calendar.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import styled from "styled-components";
+import { useTasksStore } from "../../store/feature/tasksStore";
+import {useAuthStore} from "../../store/feature/authStore";
 
 interface DayBoxProps {
     isCurrentMonth: boolean;
@@ -10,8 +12,37 @@ interface CalendarProps {
     month: number; // 0: 1월, 11: 12월
 }
 
+// 날짜별로 할 일을 정리하는 함수
+const formatDateKey = (dateString: string): string => {
+    return new Date(dateString).toISOString().split("T")[0]; // "2025-02-10"
+};
+
+const organizeTasksByDate = (tasks: { todoAt: string; title: string; color : string }[]) => {
+    return tasks.reduce((acc, task) => {
+        const dateKey = formatDateKey(task.todoAt);
+        if (!acc[dateKey]) acc[dateKey] = [];
+
+        acc[dateKey].push({ title: task.title, color: task.color }); // 객체 형식으로 저장
+        return acc;
+    }, {} as Record<string, { title: string; color: string }[]>);
+};
+
 export const Calendar = ({year, month}: CalendarProps) => {
-    const generateDays = (year: number, month: number) => {
+    const { tasks } = useTasksStore();  // 할 일 데이터 가져오기
+    const { isLoggedIn } = useAuthStore(); // 로그인 상태 가져오기
+
+    // 날짜별 할 일 정리
+    const tasksByDate = organizeTasksByDate(tasks.map(task => ({
+        todoAt: task.todoAt,
+        title: task.title,
+        color: task.color,
+    })));
+
+    const generateDays = (
+        year: number,
+        month: number,
+        tasksByDate: Record<string, { title: string; color: string }[]>
+    ) => {
         const today = new Date(); // 오늘 날짜
         const isToday = (d: number, m: number, y: number) =>
             d === today.getDate() && m === today.getMonth() && y === today.getFullYear();
@@ -19,7 +50,6 @@ export const Calendar = ({year, month}: CalendarProps) => {
         const firstDayOfMonth = new Date(year, month, 1).getDay(); // 해당 달의 첫 요일
         const daysInMonth = new Date(year, month + 1, 0).getDate(); // 해당 달의 총 일수
         const totalCells = Math.ceil((firstDayOfMonth + daysInMonth) / 7) * 7; // 필요한 셀 개수 계산
-
         const prevMonthDays = new Date(year, month, 0).getDate(); // 이전 달의 총 일수
 
         return Array.from({ length: totalCells }, (_, i) => {
@@ -33,35 +63,49 @@ export const Calendar = ({year, month}: CalendarProps) => {
                 return { day: dayNumber - daysInMonth, isCurrentMonth: false, isToday: false, tasks: [] };
             } else {
                 // 현재 달의 날짜
+                const dateKey = `${year}-${String(month + 1).padStart(2, "0")}-${String(dayNumber).padStart(2, "0")}`;
                 return {
                     day: dayNumber,
                     isCurrentMonth: true,
                     isToday: isToday(dayNumber, month, year),
-                    tasks: []
+                    tasks: tasksByDate[dateKey] || []
                 };
             }
         });
     };
 
-    const days = generateDays(year, month);
+    const days = generateDays(year, month, tasksByDate);
 
     return (
         <CalendarGrid>
-            {days.map((day, index) => (
-                <DayBox
-                    key={index}
-                    $isCurrentMonth={day.isCurrentMonth}
-                >
-                    <DayNumber $isToday={day.isToday}>{day.day}</DayNumber>
-                    <Tasks>
-                        {day.tasks.map((task, idx) => (
-                            <Task key={idx}>{task}</Task>
-                        ))}
-                    </Tasks>
-                </DayBox>
-            ))}
+            {days.map((day, index) => {
+                //최대 3개의 일정만 표시
+                const tasksToDisplay = isLoggedIn ? day.tasks.slice(0, 3) : [];
+                const moreCount = isLoggedIn ? day.tasks.length - 3 : 0;
+
+                return (
+                    <DayBox key={index} $isCurrentMonth={day.isCurrentMonth}>
+                        <DayNumber $isToday={day.isToday}>{day.day}</DayNumber>
+                        <Tasks>
+                            {/*로그인 상태일 때만 할 일(Task) 렌더링 */}
+                            {isLoggedIn &&
+                                tasksToDisplay.map((task, idx) => (
+                                    <Task key={idx} color={task.color}>
+                                        {task.title}
+                                    </Task>
+                                ))
+                            }
+                            {/* 초과하는 일정이 있을 경우 "+N개" 표시 */}
+                            {isLoggedIn && moreCount > 0 && (
+                                <MoreTasks>+{moreCount}개</MoreTasks>
+                            )}
+                        </Tasks>
+                    </DayBox>
+                );
+            })}
         </CalendarGrid>
     );
+
 };
 
 const CalendarGrid = styled.div`
@@ -114,13 +158,29 @@ const Tasks = styled.div`
     overflow: hidden;
 `;
 
-const Task = styled.div`
+const Task = styled.div<{ color: string }>`
+    display: flex;
+    align-items: center;
+    min-width: 54px;
+    max-width: 124px;
+    padding: 2px 12px;
+    gap: 10px;
+    align-self: stretch;
+
+    border-radius: 100px;
+    background: ${({ color }) => color}; // 할 일 색상 적용
+    color: #000;
     font-size: 12px;
-    color: ${({theme}) => theme.colors.primary};
-    background-color: ${({theme}) => theme.colors.coolGray10};
-    padding: 4px 8px;
-    border-radius: 8px;
+    font-weight: 500;
     white-space: nowrap;
-    text-overflow: ellipsis;
     overflow: hidden;
+    text-overflow: ellipsis;
+`;
+
+const MoreTasks = styled.div`
+    font-size: 12px;
+    color: ${({ theme }) => theme.colors.primary};
+    cursor: pointer;
+    text-decoration: underline;
+    margin-top: 4px;
 `;

--- a/src/pages/calendar/Calendar.tsx
+++ b/src/pages/calendar/Calendar.tsx
@@ -11,6 +11,7 @@ interface DayBoxProps {
 interface CalendarProps {
     year: number;
     month: number; // 0: 1월, 11: 12월
+    selectedTab: "all" | "plans" | "tasks";  // 필터링을 위한 prop 추가 -> 전체, 할일, 일정
 }
 
 // 날짜별로 할 일을 정리하는 함수
@@ -41,7 +42,7 @@ const organizeTasksByDate = (
     return mergedItems;
 };
 
-export const Calendar = ({year, month}: CalendarProps) => {
+export const Calendar = ({year, month, selectedTab}: CalendarProps) => {
     const { tasks } = useTasksStore();  // 할 일 데이터 가져오기
     const { plans, fetchPlans } = usePlanStore();  // plans 가져오기 + fetchPlans 추가
     const { isLoggedIn } = useAuthStore(); // 로그인 상태 가져오기
@@ -99,8 +100,15 @@ export const Calendar = ({year, month}: CalendarProps) => {
         <CalendarGrid>
             {days.map((day, index) => {
                 //최대 3개의 일정만 표시
-                const tasksToDisplay = isLoggedIn ? day.tasks.slice(0, 3) : [];
-                const moreCount = isLoggedIn ? day.tasks.length - 3 : 0;
+                const filteredTasks =
+                    selectedTab === "tasks"
+                        ? day.tasks.filter(task => !task.color.includes("#D9E2FF")) //일정과 할 일을 구분하는 조건 추가
+                        : selectedTab === "plans"
+                            ? day.tasks.filter(task => task.color.includes("#D9E2FF"))
+                            : day.tasks; // "all"이면 전체 출력
+
+                const tasksToDisplay = isLoggedIn ? filteredTasks.slice(0, 3) : [];
+                const moreCount = isLoggedIn ? filteredTasks.length - 3 : 0;
 
                 return (
                     <DayBox key={index} $isCurrentMonth={day.isCurrentMonth}>
@@ -161,7 +169,9 @@ const DayNumber = styled.div<{ $isToday: boolean }>`
     align-items: center;
     width: 40px;
     height: 40px;
-    border-radius: 100px;
+    aspect-ratio: 1 / 1; /*정사각형 유지 */
+    border-radius: 50%; /*정확한 원형 유지 */
+    flex-shrink: 0; /*부모 크기에 영향을 받지 않도록 설정 */
     background: ${({ $isToday, theme }) =>
             $isToday ? theme.colors.primary : "transparent"};
     color: ${({ $isToday, theme }) =>

--- a/src/pages/calendar/CalendarHeader.tsx
+++ b/src/pages/calendar/CalendarHeader.tsx
@@ -8,9 +8,10 @@ interface CalendarHeaderProps {
     year: number;
     month: number; // 0: 1월, 11: 12월
     changeMonth: (offset: number) => void;
+    setSelectedTab: (tab: "all" | "plans" | "tasks") => void;  // 필터링 역할
 }
 
-export const CalendarHeader = ({year, month, changeMonth }:CalendarHeaderProps) => {
+export const CalendarHeader = ({year, month, changeMonth, setSelectedTab }:CalendarHeaderProps) => {
     const monthNames = [
         "January",
         "February",
@@ -38,9 +39,9 @@ export const CalendarHeader = ({year, month, changeMonth }:CalendarHeaderProps) 
                 </button>
             </MonthNavigation>
             <TabMenu>
-                <TabButton>전체</TabButton>
-                <TabButton>일정</TabButton>
-                <TabButton>할일</TabButton>
+                <TabButton onClick={() => setSelectedTab("all")}>전체</TabButton>
+                <TabButton onClick={() => setSelectedTab("plans")}>일정</TabButton>
+                <TabButton onClick={() => setSelectedTab("tasks")}>할일</TabButton>
             </TabMenu>
         </HeaderContainer>
     );

--- a/src/pages/calendar/CalendarHeader.tsx
+++ b/src/pages/calendar/CalendarHeader.tsx
@@ -96,10 +96,6 @@ const TabButton = styled.button<{$isActive : boolean}>`
     border: 1.5px solid ${({ theme }) => theme.colors.primary};
     color: ${({ theme, $isActive }) =>
             $isActive ? theme.colors.primary : theme.colors.primary};
-
-    &:hover {
-        background-color: ${({ theme }) => theme.colors.coolGray8};
-    }
 `;
 
 const TabMenu = styled.div`

--- a/src/pages/calendar/CalendarHeader.tsx
+++ b/src/pages/calendar/CalendarHeader.tsx
@@ -9,9 +9,10 @@ interface CalendarHeaderProps {
     month: number; // 0: 1월, 11: 12월
     changeMonth: (offset: number) => void;
     setSelectedTab: (tab: "all" | "plans" | "tasks") => void;  // 필터링 역할
+    selectedTab: "all" | "plans" | "tasks";  // 버튼이 선택됬냐 아니냐에 따라 색상 변경 역할
 }
 
-export const CalendarHeader = ({year, month, changeMonth, setSelectedTab }:CalendarHeaderProps) => {
+export const CalendarHeader = ({year, month, changeMonth, setSelectedTab, selectedTab }:CalendarHeaderProps) => {
     const monthNames = [
         "January",
         "February",
@@ -39,9 +40,24 @@ export const CalendarHeader = ({year, month, changeMonth, setSelectedTab }:Calen
                 </button>
             </MonthNavigation>
             <TabMenu>
-                <TabButton onClick={() => setSelectedTab("all")}>전체</TabButton>
-                <TabButton onClick={() => setSelectedTab("plans")}>일정</TabButton>
-                <TabButton onClick={() => setSelectedTab("tasks")}>할일</TabButton>
+                <TabButton
+                    onClick={() => setSelectedTab("all")}
+                    $isActive={selectedTab === "all"}
+                >
+                    전체
+                </TabButton>
+                <TabButton
+                    onClick={() => setSelectedTab("plans")}
+                    $isActive={selectedTab === "plans"}
+                >
+                    일정
+                </TabButton>
+                <TabButton
+                    onClick={() => setSelectedTab("tasks")}
+                    $isActive={selectedTab === "tasks"}
+                >
+                    할일
+                </TabButton>
             </TabMenu>
         </HeaderContainer>
     );
@@ -67,25 +83,26 @@ const MonthNavigation = styled.div`
   }
 `;
 
+const TabButton = styled.button<{$isActive : boolean}>`
+    padding: 8px 16px;
+    border-radius: 40px;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    
+    // 선택된 탭 스타일
+    background: ${({ $isActive, theme }) =>
+            $isActive ? "rgba(99, 116, 255, 0.10)" : theme.colors.white};
+    border: 1.5px solid ${({ theme }) => theme.colors.primary};
+    color: ${({ theme, $isActive }) =>
+            $isActive ? theme.colors.primary : theme.colors.primary};
+
+    &:hover {
+        background-color: ${({ theme }) => theme.colors.coolGray8};
+    }
+`;
+
 const TabMenu = styled.div`
   display: flex;
   gap: 8px;
-`;
-
-const TabButton = styled.button`
-  padding: 8px 16px;
-    border: 1.5px solid ${({ theme }) => theme.colors.primary}; /* theme 에서 primary 가져오기 */
-    border-radius: 40px;
-  background-color: ${({ theme }) => theme.colors.coolGray10};
-  font-size: 14px;
-  color: ${({ theme }) => theme.colors.primary};
-  cursor: pointer;
-
-  &:hover {
-    background-color: ${({ theme }) => theme.colors.coolGray8};
-  }
-
-  &:active {
-    transform: scale(0.95);
-  }
 `;

--- a/src/pages/calendar/CalendarPage.tsx
+++ b/src/pages/calendar/CalendarPage.tsx
@@ -9,6 +9,7 @@ export const CalendarPage = () => {
     // 현재 날짜를 기반으로 초기 상태 설정
     const today = new Date();
     const [dateState, setDateState] = useState({ year: today.getFullYear(), month: today.getMonth() });
+    const [selectedTab, setSelectedTab] = useState<"all" | "plans" | "tasks">("all");  // 필터링 상태 추가
 
     // 월 변경 함수 (const 사용)
     const changeMonth = (offset: number) => {
@@ -27,10 +28,15 @@ export const CalendarPage = () => {
         <CalendarWrapper>
             {/* 캘린더 영역 */}
             <CalendarSection>
-                <CalendarHeader year={year} month={month} changeMonth={changeMonth} />
+                <CalendarHeader
+                    year={year}
+                    month={month}
+                    changeMonth={changeMonth}
+                    setSelectedTab={setSelectedTab}
+                />
                 <WeekDays />
                 <CalendarBody>
-                    <Calendar year={year} month={month} />
+                    <Calendar year={year} month={month} selectedTab={selectedTab} />
                 </CalendarBody>
             </CalendarSection>
 

--- a/src/pages/calendar/CalendarPage.tsx
+++ b/src/pages/calendar/CalendarPage.tsx
@@ -32,6 +32,7 @@ export const CalendarPage = () => {
                     year={year}
                     month={month}
                     changeMonth={changeMonth}
+                    selectedTab={selectedTab}
                     setSelectedTab={setSelectedTab}
                 />
                 <WeekDays />

--- a/src/pages/calendar/sidepanel/SidePanel.tsx
+++ b/src/pages/calendar/sidepanel/SidePanel.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from "react";
+import React, {useState, useEffect} from "react";
 import {TabNavigation} from "./tabnavigation/TabNavigation";
 import styled from "styled-components";
 import {AllTasksSection} from "./sections/alltasks/AllTasksSection"
@@ -17,6 +17,12 @@ export const SidePanel = () => {
 
     const [isSubmitting, setIsSubmitting] = useState(false); // 성과 제출 상태
     const [selectedTask, setSelectedTask] = useState<Task | null>(null); // 타입에 null 추가
+
+    // 탭(오늘 하루, 모든 할일, 일정) 이 변경될 때 성과 제출 상태 초기화
+    useEffect(() => {
+        setIsSubmitting(false);
+        setSelectedTask(null);
+    }, [activeTab]);
 
     // 루틴 생성 화면으로 이동
     const handleCreateRoutine = () => {
@@ -96,7 +102,17 @@ export const SidePanel = () => {
                     )}
                 </>
             )}
-            {activeTab === "allTasks" && <AllTasksSection />}
+            {activeTab === "allTasks" && (
+                isSubmitting && selectedTask ? (
+                    <SubmissionAchieve
+                        task={selectedTask}
+                        onBack={handleBackToTodayTasks}
+                        onSubmit={handleSubmitClick}
+                    />
+                ) : (
+                    <AllTasksSection onSubmit={handleStartSubmission} />
+                )
+            )}
             {activeTab === "schedule" && <ScheduleSection />}
         </PanelWrapper>
     );

--- a/src/pages/calendar/sidepanel/SubmissionAchieve.tsx
+++ b/src/pages/calendar/sidepanel/SubmissionAchieve.tsx
@@ -21,6 +21,15 @@ export const SubmissionAchieve = ({ task, onBack, onSubmit }: SubmissionProps) =
         }
     };
 
+    const formatDate = (dateString: string): string => {
+        // 날짜에서 'T' 이전까지 추출 (ISO 8601 대응)
+        const datePart = dateString.split("T")[0]; // "2025-02-10T10:00:00Z" → "2025-02-10"
+
+        // 기존 방식으로 변환
+        const [year, month, day] = datePart.split("-");
+        return `${parseInt(month, 10)}/${parseInt(day, 10)}`; // "02" → "2", "10" → "10"
+    };
+
     const handleSubmit = () => {
         onSubmit(comment, file, quizEnabled);
     };
@@ -33,7 +42,7 @@ export const SubmissionAchieve = ({ task, onBack, onSubmit }: SubmissionProps) =
             </Header>
             <Divider />
             <TaskInfo color={task.color}>
-                <TaskDate>{task.todoAt}</TaskDate>
+                <TaskDate>{formatDate(task.todoAt)}</TaskDate>
                 <TaskContent>
                     <TaskTitle>{task.title}</TaskTitle>
                 </TaskContent>

--- a/src/pages/calendar/sidepanel/sections/alltasks/AllTasksSection.tsx
+++ b/src/pages/calendar/sidepanel/sections/alltasks/AllTasksSection.tsx
@@ -37,6 +37,15 @@ export const AllTasksSection = () => {
         );
     }
 
+    const formatDate = (dateString: string): string => {
+        // 날짜에서 'T' 이전까지 추출 (ISO 8601 대응)
+        const datePart = dateString.split("T")[0]; // "2025-02-10T10:00:00Z" → "2025-02-10"
+
+        // 기존 방식으로 변환
+        const [year, month, day] = datePart.split("-");
+        return `${parseInt(month, 10)}/${parseInt(day, 10)}`; // "02" → "2", "10" → "10"
+    };
+
     // 완료된/미완료된 할 일 분리
     const completedTasks = tasks.filter((task) => task.completed);
     const incompleteTasks = tasks.filter((task) => !task.completed);
@@ -84,7 +93,7 @@ export const AllTasksSection = () => {
                         key={task.todoId}
                         color={task.color}
                     >
-                        <TaskDate>{task.todoAt}</TaskDate>
+                        <TaskDate>{formatDate(task.todoAt)}</TaskDate>
                         <TaskContent>
                             <TaskTitle>{task.title}</TaskTitle>
                             <ButtonGroup>

--- a/src/pages/calendar/sidepanel/sections/alltasks/AllTasksSection.tsx
+++ b/src/pages/calendar/sidepanel/sections/alltasks/AllTasksSection.tsx
@@ -1,12 +1,16 @@
 import React, {useEffect, useState, useCallback} from 'react';
 import styled from "styled-components";
-import {useTasksStore} from "../../../../../store/feature/tasksStore";
+import {Task, useTasksStore} from "../../../../../store/feature/tasksStore";
 import { ReactComponent as Edit } from "../../../../../assets/icons/calendar/rightsidebar/Edit.svg"
 import {SubT1, T6, T7} from "../../../../../styles/Typography";
 import {TaskCreation} from "../today/TaskCreation";
 import {useAuthStore} from "../../../../../store/feature/authStore";
 
-export const AllTasksSection = () => {
+interface AllTasksSectionProps {
+    onSubmit: (task: Task) => void;
+}
+
+export const AllTasksSection = ({onSubmit}:AllTasksSectionProps) => {
     const {tasks, fetchTasks, toggleTask, submitTask} = useTasksStore();
     const { isLoggedIn } = useAuthStore();
 
@@ -54,6 +58,11 @@ export const AllTasksSection = () => {
         setIsCreating(true); // "할 일 생성하기" 버튼 클릭 시 상태 변경
     };
 
+    const handleSubmitClick = (task: Task) => {
+        console.log("성과 제출 버튼 클릭됨 : ", task);  // 디버깅용 로그
+        onSubmit(task); // 부모 컴포넌트로 `onSubmit` 콜백 전달
+    };
+
     const handleBack = () => {
         setIsCreating(false); // TaskCreation 에서 뒤로가기 시 상태 복귀
     };
@@ -98,7 +107,7 @@ export const AllTasksSection = () => {
                             <TaskTitle>{task.title}</TaskTitle>
                             <ButtonGroup>
                                 {activeTab === "incomplete" && (
-                                    <SubmitButton onClick={() => submitTask(task.todoId)}>
+                                    <SubmitButton onClick={() => handleSubmitClick(task)}>
                                         성과 제출
                                     </SubmitButton>
                                 )}

--- a/src/pages/calendar/sidepanel/sections/alltasks/AllTasksSection.tsx
+++ b/src/pages/calendar/sidepanel/sections/alltasks/AllTasksSection.tsx
@@ -30,7 +30,7 @@ export const AllTasksSection = () => {
     if (!isLoggedIn) {
         return (
             <AllTasksWrapper>
-                <Title>오늘의 할 일</Title>
+                <Title>모든 할 일</Title>
                 <Divider />
                 <NoDataMessage>로그인 후 이용 가능합니다.</NoDataMessage>
             </AllTasksWrapper>

--- a/src/pages/calendar/sidepanel/sections/schedule/ScheduleSection.tsx
+++ b/src/pages/calendar/sidepanel/sections/schedule/ScheduleSection.tsx
@@ -35,6 +35,11 @@ export const ScheduleSection = () => {
         );
     }
 
+    // 날짜 형식을 JS의 split 을 활용하여 MM/DD 형식으로 변환
+    const formatDate = (dateString: string): string => {
+        const [year, month, day] = dateString.split("-"); // YYYY-MM-DD → [YYYY, MM, DD]
+        return `${parseInt(month, 10)}/${parseInt(day, 10)}`; // "02" → "2", "15" → "15"
+    };
 
     // 완료된/미완료된 할 일 분리
     const completedTasks = plans.filter((plan) => plan.clear);
@@ -69,7 +74,7 @@ export const ScheduleSection = () => {
                         //color={plan.color}
                     >
                         <ScheduleIndicator color={plan.color} /> {/* Indicator 추가 */}
-                        <ScheduleDate>{plan.startDate.split("T")[0]}</ScheduleDate>
+                        <ScheduleDate>{formatDate(plan.startDate)}</ScheduleDate>
                         <ScheduleContent>
                             <ScheduleTitle>{plan.title}</ScheduleTitle>
                             <ButtonGroup>

--- a/src/pages/calendar/sidepanel/sections/schedule/ScheduleSection.tsx
+++ b/src/pages/calendar/sidepanel/sections/schedule/ScheduleSection.tsx
@@ -28,7 +28,7 @@ export const ScheduleSection = () => {
     if (!isLoggedIn) {
         return (
             <ScheduleWrapper>
-                <Title>오늘의 할 일</Title>
+                <Title>일정</Title>
                 <Divider />
                 <NoDataMessage>로그인 후 이용 가능합니다.</NoDataMessage>
             </ScheduleWrapper>

--- a/src/pages/calendar/sidepanel/sections/schedule/ScheduleSection.tsx
+++ b/src/pages/calendar/sidepanel/sections/schedule/ScheduleSection.tsx
@@ -1,10 +1,212 @@
-import React from 'react';
+import React, {useCallback, useState, useEffect} from "react";
+import styled from "styled-components";
+import { ReactComponent as Edit } from "../../../../../assets/icons/calendar/rightsidebar/Edit.svg"
+import {SubT1, T6, T7} from "../../../../../styles/Typography";
+import { usePlanStore } from "../../../../../store/feature/planStore";
+import {useAuthStore} from "../../../../../store/feature/authStore";
+
 
 export const ScheduleSection = () => {
+    const { plans, fetchPlans, togglePlan, submitPlan } = usePlanStore();
+    const {isLoggedIn} = useAuthStore();
+
+    const [activeTab, setActiveTab] = useState<"incomplete" | "completed">("incomplete");
+
+    // useCallback 을 사용하여 함수 메모이제이션
+    const fetchPlansIfLoggedIn = useCallback(() => {
+        if (isLoggedIn) {
+            fetchPlans(2025, 2);
+        }
+    }, [isLoggedIn, fetchPlans]);
+
+    // isLoggedIn이 true 로 변경될 때만 fetchTasks 실행
+    useEffect(() => {
+        fetchPlansIfLoggedIn();
+    }, [fetchPlansIfLoggedIn]);
+
+    // 로그인하지 않은 경우 아예 컴포넌트 렌더링하지 않음
+    if (!isLoggedIn) {
+        return (
+            <ScheduleWrapper>
+                <Title>오늘의 할 일</Title>
+                <Divider />
+                <NoDataMessage>로그인 후 이용 가능합니다.</NoDataMessage>
+            </ScheduleWrapper>
+        );
+    }
+
+
+    // 완료된/미완료된 할 일 분리
+    const completedTasks = plans.filter((plan) => plan.clear);
+    const incompleteTasks = plans.filter((plan) => !plan.clear);
+
+    const scheduleToRender = activeTab === "incomplete" ? incompleteTasks : completedTasks;
     return (
-        <div>
-            바보
-        </div>
+        <ScheduleWrapper>
+            <Header>
+                <Title>일정</Title>
+                <Edit/>
+            </Header>
+            <Divider/>
+            <Tabs>
+                <TabButton
+                    selected={activeTab === "incomplete"}
+                    onClick={() => setActiveTab("incomplete")}
+                >
+                    미완료
+                </TabButton>
+                <TabButton
+                    selected={activeTab === "completed"}
+                    onClick={() => setActiveTab("completed")}
+                >
+                    완료
+                </TabButton>
+            </Tabs>
+            <SchedulesList>
+                {scheduleToRender.map((plan) => (
+                    <ScheduleItem
+                        key={plan.planId}
+                        //color={plan.color}
+                    >
+                        <ScheduleIndicator color={plan.color} /> {/* Indicator 추가 */}
+                        <ScheduleDate>{plan.startDate.split("T")[0]}</ScheduleDate>
+                        <ScheduleContent>
+                            <ScheduleTitle>{plan.title}</ScheduleTitle>
+                            <ButtonGroup>
+                                <Checkbox
+                                    type="checkbox"
+                                    checked={plan.clear}
+                                    onChange={() => togglePlan(plan.planId)}
+                                />
+                            </ButtonGroup>
+                        </ScheduleContent>
+                    </ScheduleItem>
+                ))}
+            </SchedulesList>
+            <CreateButton>성과 제출하기</CreateButton>
+        </ScheduleWrapper>
     );
 };
 
+
+const ScheduleWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    min-width: 310px;
+    max-width: 460px;
+    padding: 24px;
+    align-items: flex-start;
+    gap: 20px;
+    align-self: stretch;
+    border-radius: 20px;
+    background: #fff; /* White */
+`;
+
+const Header = styled.div`
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+`;
+
+const Title = styled(T6)`
+`;
+
+const Divider = styled.div`
+    width: 100%;
+    height: 1px;
+    background-color: #d4d6eb;
+    // margin: 16px 0;
+`;
+
+const Tabs = styled.div`
+    display: flex;
+    gap: 8px;
+`;
+
+const TabButton = styled(T7).attrs<{ selected?: boolean }>({ as: "button" })`
+    background: ${(props) => (props.selected ? "#6373FF" : "#F6F7FF")};
+    color: ${(props) => (props.selected ? "#FFF" : "#6373FF")};
+    padding: 8px 20px;
+    border-radius: 40px;
+    border: none;
+    cursor: pointer;
+`;
+
+const SchedulesList = styled.ul`
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    width: 100%;
+`;
+
+const ScheduleDate = styled.div`
+    font-size: 12px;
+    color: #333;
+    padding: 4px 8px;
+    background: #f0f0f0;
+    border-radius: 4px;
+`;
+
+const ScheduleItem = styled.li`
+    display: flex;
+    align-items: center;
+    width: 100%;
+    padding: 12px 12px 12px 32px; /* Figma 기준 padding 적용 */
+    border-radius: 8px;
+    border: 1px solid #CACCD7;
+    background: #FFF;
+    position: relative; /* ScheduleIndicator 위치 고정 */
+    margin-bottom: 8px;
+`;
+
+const ScheduleIndicator = styled.div<{ color: string }>`
+    width: 20px;
+    height: 52px;
+    border-radius: 8px 0px 0px 8px;
+    background: ${({ color }) => color};
+    position: absolute; // 위치 고정 
+    left: 0; // ScheduleItem 의 왼쪽에 배치 
+    top: 50%;
+    transform: translateY(-50%); //세로 중앙 정렬 
+`;
+
+const ScheduleContent = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex: 1;
+    width: 100%;
+    padding-left: 24px; //Indicator와 내용 간 간격 조정 */
+`;
+
+const ScheduleTitle = styled(SubT1)`
+`;
+
+const ButtonGroup = styled.div`
+    display: flex;
+    align-items: center; /* 수직 정렬 */
+    gap: 8px; /* 버튼과 체크박스 사이 간격 */
+`;
+
+const Checkbox = styled.input`
+    width: 20px;
+    height: 20px;
+`;
+
+const CreateButton = styled(T6).attrs({ as: "button" })`
+    width: 100%;
+    padding: 20px;
+    background: #fff;
+    color: #6373FF;
+    border: 1px solid #5F74FF;
+    border-radius: 8px;
+    cursor: pointer;
+`;
+
+const NoDataMessage = styled.p`
+    font-size: 16px;
+    color: #999;
+    text-align: center;
+    width: 100%;
+    margin-top: 20px;
+`;

--- a/src/pages/calendar/sidepanel/sections/today/Routine.tsx
+++ b/src/pages/calendar/sidepanel/sections/today/Routine.tsx
@@ -49,7 +49,7 @@ export const Routine = ({ onCreate }: { onCreate: () => void }) => {
                 {routines.map((routine) => (
                     <RoutineItem
                         key={routine.routine_id}
-                        completed={routine.isClear}
+                        $completed={routine.isClear}
                     >
                         <TaskTitle>{routine.title}</TaskTitle>
                         <Checkbox
@@ -109,7 +109,7 @@ const RoutineList = styled.ul`
     width: 100%;
 `;
 
-const RoutineItem = styled.li<{ completed: boolean }>`
+const RoutineItem = styled.li<{ $completed: boolean }>`
     display: flex;
     justify-content: space-between; /* 체크박스와 텍스트를 양쪽에 배치 */
     align-items: center;
@@ -119,10 +119,10 @@ const RoutineItem = styled.li<{ completed: boolean }>`
     gap: 12px;
     align-self: stretch;
     border-radius: 8px;
-    background-color: ${({ completed, theme }) =>
-            completed ? theme.colors.coolGray10 : "#FFFFFF"}; /* 완료 여부에 따른 배경색 */
-    border: ${({ completed, theme }) =>
-            completed ? "none" : "0.4px solid #2D2D2D"}; /* 완료되지 않은 경우 테두리 추가 */
+    background-color: ${({ $completed, theme }) =>
+            $completed ? theme.colors.coolGray10 : "#FFFFFF"}; /* 완료 여부에 따른 배경색 */
+    border: ${({ $completed, theme }) =>
+            $completed ? "none" : "0.4px solid #2D2D2D"}; /* 완료되지 않은 경우 테두리 추가 */
     margin-bottom: 8px; /* 아이템 간격 추가 */
 
     &:last-child {

--- a/src/pages/calendar/sidepanel/sections/today/Routine.tsx
+++ b/src/pages/calendar/sidepanel/sections/today/Routine.tsx
@@ -12,6 +12,7 @@ export const Routine = ({ onCreate }: { onCreate: () => void }) => {
     const {isLoggedIn} = useAuthStore();
 
     useEffect(() => {
+        console.log("isLoggedIn", isLoggedIn);
         if (isLoggedIn) {
             fetchRoutines();
         }

--- a/src/pages/calendar/sidepanel/sections/today/TodayTasks.tsx
+++ b/src/pages/calendar/sidepanel/sections/today/TodayTasks.tsx
@@ -17,6 +17,7 @@ export const TodayTasks = ({ onCreateTask, onSubmit }: TaskProps) => {
     const { isLoggedIn } = useAuthStore();  // zustand 에서 로그인 상태 가져오기
 
     useEffect(() => {
+        console.log("isLoggedIn", isLoggedIn);
         if (isLoggedIn) {
             fetchTasks(); // 로그인한 경우에만 데이터를 불러오기
         }

--- a/src/pages/calendar/sidepanel/sections/today/TodayTasks.tsx
+++ b/src/pages/calendar/sidepanel/sections/today/TodayTasks.tsx
@@ -52,12 +52,12 @@ export const TodayTasks = ({ onCreateTask, onSubmit }: TaskProps) => {
             {/* 완료된 할 일 섹션 */}
             {completedTasks.length > 0 && (
                 <>
-                    <SectionHeader completed={true}>완료</SectionHeader>
+                    <SectionHeader $completed={true}>완료</SectionHeader>
                     <TasksList>
                         {completedTasks.map((task) => (
                             <TaskItem
                                 key={task.todoId}
-                                completed={task.completed}
+                                $completed={task.completed}
                                 color={task.color}
                             >
                                 <TaskDate>{task.todoAt}</TaskDate>
@@ -78,12 +78,12 @@ export const TodayTasks = ({ onCreateTask, onSubmit }: TaskProps) => {
             <TasksListWrapper/>
             {incompleteTasks.length > 0 && (
                 <>
-                    <SectionHeader completed={false}>미완료</SectionHeader>
+                    <SectionHeader $completed={false}>미완료</SectionHeader>
                     <TasksList>
                         {incompleteTasks.map((task) => (
                             <TaskItem
                                 key={task.todoId}
-                                completed={task.completed}
+                                $completed={task.completed}
                                 color={task.color}
                             >
                                 <TaskDate>{task.todoAt}</TaskDate>
@@ -124,11 +124,11 @@ const TasksWrapper = styled.div`
 `;
 
 // 완료/미완료 섹션 헤더 스타일
-const SectionHeader = styled(T7).attrs<{ completed: boolean }>({})`
+const SectionHeader = styled(T7).attrs<{ $completed: boolean }>({})`
     display: inline-block;
     padding: 8px 20px; /* 내부 여백 추가 */
-    color: ${({ completed }) => (completed ? "#6373FF" : "#FFF")};
-    background-color: ${({ completed }) => (completed ? "#F6F7FF" : "#6373FF")}; /* 배경색 */
+    color: ${({ $completed }) => ($completed ? "#6373FF" : "#FFF")};
+    background-color: ${({ $completed }) => ($completed ? "#F6F7FF" : "#6373FF")}; /* 배경색 */
     border-radius: 40px; /* 둥근 테두리 */
     text-align: center;
 `;
@@ -177,15 +177,15 @@ const ButtonGroup = styled.div`
     gap: 8px; /* 버튼과 체크박스 사이 간격 */
 `;
 
-const TaskItem = styled.li<{ completed: boolean; color: string }>`
+const TaskItem = styled.li<{ $completed: boolean; color: string }>`
     width: 100%;
     display: flex;
     align-items: center;
     gap: 12px;
     padding: 12px;
     border-radius: 8px;
-    background-color: ${({ completed, color, theme }) =>
-            completed ? theme.colors.coolGray10 : color}; /* 완료 여부에 따라 배경색 설정 */
+    background-color: ${({ $completed, color, theme }) =>
+            $completed ? theme.colors.coolGray10 : color}; /* 완료 여부에 따라 배경색 설정 */
     margin-bottom: 8px;
 
     &:last-child {

--- a/src/pages/calendar/sidepanel/sections/today/TodayTasks.tsx
+++ b/src/pages/calendar/sidepanel/sections/today/TodayTasks.tsx
@@ -42,8 +42,14 @@ export const TodayTasks = ({ onCreateTask, onSubmit }: TaskProps) => {
         return `${parseInt(month, 10)}/${parseInt(day, 10)}`; // "02" → "2", "10" → "10"
     };
 
-    const completedTasks = tasks.filter((task) => task.completed);
-    const incompleteTasks = tasks.filter((task) => !task.completed);
+    // 오늘 날짜 구하기
+    const todayDate = new Date().toISOString().split("T")[0]; // "2025-02-20"
+
+    // 오늘 할 일만 필터링
+    const todayTasks = tasks.filter((task) => task.todoAt.split("T")[0] === todayDate);
+
+    const completedTasks = todayTasks.filter((task) => task.completed);
+    const incompleteTasks = todayTasks.filter((task) => !task.completed);
 
     const handleSubmitClick = (task: Task) => {
         onSubmit(task); // 부모 컴포넌트로 `onSubmit` 콜백 전달

--- a/src/pages/calendar/sidepanel/sections/today/TodayTasks.tsx
+++ b/src/pages/calendar/sidepanel/sections/today/TodayTasks.tsx
@@ -33,6 +33,15 @@ export const TodayTasks = ({ onCreateTask, onSubmit }: TaskProps) => {
         );
     }
 
+    const formatDate = (dateString: string): string => {
+        // 날짜에서 'T' 이전까지 추출 (ISO 8601 대응)
+        const datePart = dateString.split("T")[0]; // "2025-02-10T10:00:00Z" → "2025-02-10"
+
+        // 기존 방식으로 변환
+        const [year, month, day] = datePart.split("-");
+        return `${parseInt(month, 10)}/${parseInt(day, 10)}`; // "02" → "2", "10" → "10"
+    };
+
     const completedTasks = tasks.filter((task) => task.completed);
     const incompleteTasks = tasks.filter((task) => !task.completed);
 
@@ -61,7 +70,7 @@ export const TodayTasks = ({ onCreateTask, onSubmit }: TaskProps) => {
                                 $completed={task.completed}
                                 color={task.color}
                             >
-                                <TaskDate>{task.todoAt}</TaskDate>
+                                <TaskDate>{formatDate(task.todoAt)}</TaskDate>
                                 <TaskContent>
                                     <TaskTitle>{task.title}</TaskTitle>
                                     <Checkbox
@@ -87,7 +96,7 @@ export const TodayTasks = ({ onCreateTask, onSubmit }: TaskProps) => {
                                 $completed={task.completed}
                                 color={task.color}
                             >
-                                <TaskDate>{task.todoAt}</TaskDate>
+                                <TaskDate>{formatDate(task.todoAt)}</TaskDate>
                                 <TaskContent>
                                     <TaskTitle>{task.title}</TaskTitle>
                                     <ButtonGroup>

--- a/src/pages/calendar/sidepanel/tabnavigation/TabNavigation.tsx
+++ b/src/pages/calendar/sidepanel/tabnavigation/TabNavigation.tsx
@@ -20,7 +20,7 @@ export const TabNavigation = ({ activeTab, setActiveTab }: TabNavigationProps) =
             {tabs.map((tab) => (
                 <TabButton
                     key={tab.id}
-                    isActive={activeTab === tab.id}
+                    $isActive={activeTab === tab.id}
                     onClick={() => setActiveTab(tab.id)}
                 >
                     {tab.label}
@@ -42,7 +42,7 @@ const TabWrapper = styled.div`
   background: ${({ theme }) => theme.colors.white}; 
 `;
 
-const TabButton = styled.button<{ isActive: boolean }>`
+const TabButton = styled.button<{ $isActive: boolean }>`
   flex: 1; /* 각 탭 버튼이 동일한 너비를 가짐 */
   padding: 10px 16px;
   font-size: 14px;
@@ -51,15 +51,15 @@ const TabButton = styled.button<{ isActive: boolean }>`
   border: none;
   border-radius: 12px;
   cursor: pointer;
-  background: ${({ isActive, theme }) =>
-    isActive ? theme.colors.primary || "#6673FF" : theme.colors.white || "#FFF"};
-  color: ${({ isActive, theme }) =>
-    isActive ? theme.colors.white || "#FFF" : theme.colors.gray700 || "#333"};
-  box-shadow: ${({ isActive }) =>
-    isActive ? "0px 4px 8px rgba(0, 0, 0, 0.1)" : "none"};
+  background: ${({ $isActive, theme }) =>
+    $isActive ? theme.colors.primary || "#6673FF" : theme.colors.white || "#FFF"};
+  color: ${({ $isActive, theme }) =>
+    $isActive ? theme.colors.white || "#FFF" : theme.colors.gray700 || "#333"};
+  box-shadow: ${({ $isActive }) =>
+    $isActive ? "0px 4px 8px rgba(0, 0, 0, 0.1)" : "none"};
 
   &:hover {
-    background: ${({ isActive, theme }) =>
-    isActive ? theme.colors.primaryDark || "#6673FF" : "#F0F0F0"};
+    background: ${({ $isActive, theme }) =>
+    $isActive ? theme.colors.primaryDark || "#6673FF" : "#F0F0F0"};
   }
 `;

--- a/src/store/feature/authStore.ts
+++ b/src/store/feature/authStore.ts
@@ -18,21 +18,21 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
     // Access Token 설정
     setAccessToken: (token) => {
-        set({ isLoggedIn: true, accessToken: token  });  // 로그인 상태 유지
         localStorage.setItem("accessToken", token); // localStorage에도 저장
+        set({ isLoggedIn: true, accessToken: token  });  // 로그인 상태 유지
         get().fetchUserInfo();  // 로그인 후 사용자 정보 가져오기
     },
 
     // Access Token 제거
     clearAccessToken: () => {
-        set({ isLoggedIn: false, accessToken: null });  // 로그아웃시 사용할 것 같네요.
-        localStorage.removeItem("accessToken"); // localStorage에서도 삭제
+        set({ isLoggedIn: false, accessToken: null });  // 로그아웃시 사용할 것 같네요. -> localStorage에서 제거
+        localStorage.removeItem("accessToken"); // localStorage에서도 삭제 -> 상태 초기화
     },
 
-    // ✅ 사용자 정보 가져오기 API 호출
+    // 사용자 정보 가져오기 API 호출
     fetchUserInfo: async () => {
         const token = get().accessToken || localStorage.getItem("accessToken");
-        if (!token) return;
+        if (!token) return;  // 토큰이 없으면 실행하지 않음
 
         try {
             const response = await fetch("http://localhost:8080/findOne", {
@@ -46,6 +46,8 @@ export const useAuthStore = create<AuthState>((set, get) => ({
                 console.log("✅ 사용자 정보:", userData);
             } else {
                 console.error("❌ 사용자 정보 불러오기 실패", response.status);
+                set({ isLoggedIn: false, accessToken: null, userInfo: null }); // 로그인 상태 초기화
+                localStorage.removeItem("accessToken"); // 잘못된 토큰이면 삭제
             }
         } catch (error) {
             console.error("❌ 사용자 정보 요청 중 오류 발생:", error);

--- a/src/store/feature/planStore.ts
+++ b/src/store/feature/planStore.ts
@@ -26,6 +26,7 @@ const dummyPlans: Plan[] = [
     { planId: 1, title: "스터디 모임", startDate: "2025-02-10T10:00:00Z", endDate: "2025-02-10T12:00:00Z", color: "#FFD8DA", alarm: true, comment: "", clear: false },
     { planId: 2, title: "운동하기", startDate: "2025-02-12T18:00:00Z", endDate: "2025-02-12T19:00:00Z", color: "#FFE8C9", alarm: false, comment: "", clear: true },
     { planId: 3, title: "친구 만나기", startDate: "2025-02-15T15:00:00Z", endDate: "2025-02-15T17:00:00Z", color: "#D9E2FF", alarm: true, comment: "", clear: false },
+    { planId: 4, title: "놀기", startDate: "2025-02-20T15:00:00Z", endDate: "2025-02-21T17:00:00Z", color: "#D9E2FF", alarm: true, comment: "", clear: false }
 ];
 
 export const usePlanStore = create<PlanState>((set) => ({

--- a/src/store/feature/planStore.ts
+++ b/src/store/feature/planStore.ts
@@ -1,0 +1,71 @@
+// 캘린더 우측 사이드바에서 일정 관한 상태를 관리하기 위한 store 입니다.
+
+import {create} from "zustand";
+import axios from "axios";
+
+export interface Plan {
+    planId: number;
+    title: string;
+    startDate: string;
+    endDate: string;
+    color: string;
+    alarm: boolean;
+    comment: string;
+    clear: boolean;
+}
+
+interface PlanState {
+    plans: Plan[];
+    fetchPlans: (year: number, month: number) => Promise<void>;
+    togglePlan: (id: number) => void;
+    submitPlan: (id: number) => void;
+}
+
+// 더미 데이터
+const dummyPlans: Plan[] = [
+    { planId: 1, title: "스터디 모임", startDate: "2025-02-10T10:00:00Z", endDate: "2025-02-10T12:00:00Z", color: "#FFD8DA", alarm: true, comment: "", clear: false },
+    { planId: 2, title: "운동하기", startDate: "2025-02-12T18:00:00Z", endDate: "2025-02-12T19:00:00Z", color: "#FFE8C9", alarm: false, comment: "", clear: true },
+    { planId: 3, title: "친구 만나기", startDate: "2025-02-15T15:00:00Z", endDate: "2025-02-15T17:00:00Z", color: "#D9E2FF", alarm: true, comment: "", clear: false },
+];
+
+export const usePlanStore = create<PlanState>((set) => ({
+    plans: [],
+
+    // 일정 데이터 가져오기
+    fetchPlans: async (year, month) => {
+        try {
+            console.warn("API 호출을 비활성화하고 더미 데이터를 로드합니다.");
+
+            // API 호출을 비활성화하고 더미 데이터만 사용
+            set({ plans: dummyPlans });
+
+            // 이후 실제 API 연결 시 주석 해제
+            // const response = await axios.get(`/api/v1/plan/${year}/${month}`, {
+            //     headers: {
+            //         Authorization: `Bearer ${localStorage.getItem("access_token")}`,
+            //     },
+            // });
+            // set({ plans: response.data });
+
+        } catch (error) {
+            console.error("Error fetching plans:", error);
+            set({ plans: dummyPlans });
+        }
+    },
+
+    // 일정 완료/미완료 토글
+    togglePlan: (id) =>
+        set((state) => ({
+            plans: state.plans.map((plan) =>
+                plan.planId === id ? { ...plan, clear: !plan.clear } : plan
+            ),
+        })),
+
+    // 성과 제출
+    submitPlan: (id) =>
+        set((state) => ({
+            plans: state.plans.map((plan) =>
+                plan.planId === id ? { ...plan, comment: "제출 완료" } : plan
+            ),
+        })),
+}));

--- a/src/store/feature/tasksStore.ts
+++ b/src/store/feature/tasksStore.ts
@@ -25,8 +25,11 @@ interface TasksState {
 // 더미 데이터
 const dummyTasks: Task[] = [
     { todoId: 1, title: "리액트 공부하기", todoAt: "2025-02-19T10:00:00Z", color: "#FFD8DA", planAlarm: true, planComment: "", completed: false },
-    { todoId: 2, title: "잠자기", todoAt: "2025-02-19T10:00:00Z", color: "#FFE8C9", planAlarm: false, planComment: "", completed: true },
-    { todoId: 3, title: "스프링 공부하기", todoAt: "2025-02-20T10:00:00Z", color: "#D9E2FF" , planAlarm: true, planComment: "", completed: false },
+    { todoId: 2, title: "스프링 공부하기", todoAt: "2025-02-19T10:00:00Z", color: "#FFE8C9", planAlarm: false, planComment: "", completed: true },
+    { todoId: 3, title: "요리", todoAt: "2025-02-19T10:00:00Z", color: "#FFE8C9", planAlarm: false, planComment: "", completed: true },
+    { todoId: 4, title: "테스트1", todoAt: "2025-02-19T10:00:00Z", color: "#FFE8C9", planAlarm: false, planComment: "", completed: true },
+    { todoId: 5, title: "테스트7", todoAt: "2025-02-19T10:00:00Z", color: "#FFE8C9", planAlarm: false, planComment: "", completed: true },
+    { todoId: 6, title: "타스 공부하기", todoAt: "2025-02-20T10:00:00Z", color: "#D9E2FF" , planAlarm: true, planComment: "", completed: false },
 ];
 
 export const useTasksStore = create<TasksState>((set) => ({

--- a/src/store/feature/tasksStore.ts
+++ b/src/store/feature/tasksStore.ts
@@ -27,9 +27,9 @@ const dummyTasks: Task[] = [
     { todoId: 1, title: "리액트 공부하기", todoAt: "2025-02-19T10:00:00Z", color: "#FFD8DA", planAlarm: true, planComment: "", completed: false },
     { todoId: 2, title: "스프링 공부하기", todoAt: "2025-02-19T10:00:00Z", color: "#FFE8C9", planAlarm: false, planComment: "", completed: true },
     { todoId: 3, title: "요리", todoAt: "2025-02-19T10:00:00Z", color: "#FFE8C9", planAlarm: false, planComment: "", completed: true },
-    { todoId: 4, title: "테스트1", todoAt: "2025-02-19T10:00:00Z", color: "#FFE8C9", planAlarm: false, planComment: "", completed: true },
-    { todoId: 5, title: "테스트7", todoAt: "2025-02-19T10:00:00Z", color: "#FFE8C9", planAlarm: false, planComment: "", completed: true },
-    { todoId: 6, title: "타스 공부하기", todoAt: "2025-02-20T10:00:00Z", color: "#D9E2FF" , planAlarm: true, planComment: "", completed: false },
+    //{ todoId: 4, title: "타스 공부하기", todoAt: "2025-02-20T10:00:00Z", color: "#D9E2FF" , planAlarm: true, planComment: "", completed: false },
+    //{ todoId: 5, title: "AI 공부하기", todoAt: "2025-02-20T10:00:00Z", color: "#D9E2FF" , planAlarm: true, planComment: "", completed: false },
+    { todoId: 4, title: "타스 공부하기", todoAt: "2025-02-18T10:00:00Z", color: "#D9E2FF" , planAlarm: true, planComment: "", completed: false },
 ];
 
 export const useTasksStore = create<TasksState>((set) => ({

--- a/src/store/feature/tasksStore.ts
+++ b/src/store/feature/tasksStore.ts
@@ -24,9 +24,9 @@ interface TasksState {
 
 // 더미 데이터
 const dummyTasks: Task[] = [
-    { todoId: 1, title: "리액트 공부하기", todoAt: "2/12", color: "#FFD8DA", planAlarm: true, planComment: "", completed: false },
-    { todoId: 2, title: "잠자기", todoAt: "2/12", color: "#FFE8C9", planAlarm: false, planComment: "", completed: true },
-    { todoId: 3, title: "스프링 공부하기", todoAt: "2/21", color: "#D9E2FF" , planAlarm: true, planComment: "", completed: false },
+    { todoId: 1, title: "리액트 공부하기", todoAt: "2025-02-19T10:00:00Z", color: "#FFD8DA", planAlarm: true, planComment: "", completed: false },
+    { todoId: 2, title: "잠자기", todoAt: "2025-02-19T10:00:00Z", color: "#FFE8C9", planAlarm: false, planComment: "", completed: true },
+    { todoId: 3, title: "스프링 공부하기", todoAt: "2025-02-20T10:00:00Z", color: "#D9E2FF" , planAlarm: true, planComment: "", completed: false },
 ];
 
 export const useTasksStore = create<TasksState>((set) => ({


### PR DESCRIPTION
## 주요 변경사항
- 달력헤더 상단에 일정, 할일, 전체 로 필터링
- "오늘의 할 일" -> 오늘 날짜의 할 일만 필터링
- 일정, 할 일 -> 달력 컴포넌트에 표시

## 개발 내용
- [x] 완료된 할 일, 미완료된 할 일 렌더링 로직 수정
- [x] TodayTasks.tsx 에서 전체 데이터가 렌더링되는 문제 해결
- [x] 오늘 할 일 필터링 적용
- [x] 달력 컴포넌트에 일정, 할 일 표시 및 필터링

## 추가 고려사항
- 다른 컴포넌트에서도 'tasks' 전체 데이터를 필터링 없이 사횽하고 있을 가능성 검토
- 추가로 더미 데이터를 활용 혹은 API를 연결해 테스트 데이터를 통해 데이터가 많아졌을 시 어떻게 렌더링 되는가 모니터링 확인 필요
- fetchTasks() 호출 시 불필요한 데이터가 포함되는지 확인 필요